### PR TITLE
Add Xcode to setup instructions for MacOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@
 ## Dev Setup
 
 MacOS:
+ - Install [Xcode](https://apps.apple.com/us/app/xcode/id497799835)
  - Install homebrew: `/usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"`.
  - Install python3, git and openssl: `brew install git python3 openssl`.
  - Add path to flags: `export LDFLAGS="-L$(brew --prefix openssl)/lib"` & `export CFLAGS="-I$(brew --prefix openssl)/include"`.


### PR DESCRIPTION
Xcode should also be listed as a requirement for MacOS.