### PR TITLE
(Verification in Progress) Adding virtual env installation to centos

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,3 +59,6 @@ _init_centos:
 	which docker || { curl -fsSL https://get.docker.com/ | sh; sudo systemctl start docker; sudo systemctl enable docker; sudo usermod -aG docker $(whoami); }
 
 	rpm -q python36 || sudo yum -y install python36 python-pip python3-devel
+
+	# Install virtual env
+	sudo pip install -U virtualenv


### PR DESCRIPTION
make _init_centos does not ensure installation of virtual env
Added step to install virtual env. Without virtual_env, "make dev" might fail if it was not pre-installed

Via the pull request, installation step is added.

Verified it on my dev VM.
Want to verify few more times on different dev vm if there are more steps required for same.