### PR TITLE
Add better connection error info when PC connection fails

### DIFF
--- a/calm/dsl/api/connection.py
+++ b/calm/dsl/api/connection.py
@@ -265,7 +265,11 @@ class Connection:
                 if not res.ok:
                     LOG.debug("Server Response: {}".format(res.json()))
         except ConnectTimeout as cte:
-            LOG.error("Could not establish connection to server.")
+            LOG.error(
+                "Could not establish connection to server at {}:{}.".format(
+                    self.host, self.port
+                )
+            )
             LOG.debug("Error Response: {}".format(cte))
             sys.exit(-1)
         except Exception as ex:


### PR DESCRIPTION
As per channel discussion on April 8th 2020.  This branch adds slightly better error message info when the connection from user to Prism Central fails.

- Previously, the DSL would simply acknowledged and informed the user of the error
- Now added info on the IP address and port that was used during the failed connection

![calm-dsl-timeout-3](https://user-images.githubusercontent.com/423229/78745825-a05ae700-79a8-11ea-886b-d5888b33ea27.png)
