### PR TITLE
Topic/fix cache entity request length

### DIFF
--- a/calm/dsl/store/cache.py
+++ b/calm/dsl/store/cache.py
@@ -80,8 +80,8 @@ class Cache:
             api_suffix = cls.entity_type_api_map[entity_type]
             Obj = get_resource_api(api_suffix, client.connection)
             try:
-                res = Obj.get_name_uuid_map()
-                for name, uuid in res.items({"length": 100}):
+                res = Obj.get_name_uuid_map({"length": 100})
+                for name, uuid in res.items():
                     cls.create(
                         entity_type=entity_type, entity_name=name, entity_uuid=uuid
                     )

--- a/calm/dsl/store/cache.py
+++ b/calm/dsl/store/cache.py
@@ -81,7 +81,7 @@ class Cache:
             Obj = get_resource_api(api_suffix, client.connection)
             try:
                 res = Obj.get_name_uuid_map()
-                for name, uuid in res.items():
+                for name, uuid in res.items({"length": 100}):
                     cls.create(
                         entity_type=entity_type, entity_name=name, entity_uuid=uuid
                     )


### PR DESCRIPTION
Fixed problem when running:

    calm update cache

Without this change, PC instances with >20 images may not return images with names **Centos7** and **AHV_CENTOS_76** in the response and therefore may fail tests even when those images are present.

This screenshot is from a PC instance that does have images named as per above, but they weren't getting returned:

![Screenshot_20200408_165416](https://user-images.githubusercontent.com/423229/78765314-2daf3300-79cb-11ea-8478-8162a063ea23.png)

Example of error returned by _make test_, even though the images are there:

![Screenshot_20200408_165207](https://user-images.githubusercontent.com/423229/78765411-4d465b80-79cb-11ea-87e7-576f909e8350.png)
