### PR TITLE
Cli changes to add version control changes for various commands

### DIFF
--- a/calm/dsl/cli/app_commands.py
+++ b/calm/dsl/cli/app_commands.py
@@ -3,7 +3,7 @@ import click
 from calm.dsl.api import get_api_client
 
 from .main import main, get, describe, delete, run, watch, download
-from .utils import Display
+from .utils import Display, FeatureFlagGroup
 from .apps import (
     get_apps,
     describe_app,
@@ -155,19 +155,19 @@ def _delete_app(app_names, soft):
     delete_app(app_names, soft)
 
 
-@main.group()
+@main.group(cls=FeatureFlagGroup)
 def start():
     """Start entities"""
     pass
 
 
-@main.group()
+@main.group(cls=FeatureFlagGroup)
 def stop():
     """Stop entities"""
     pass
 
 
-@main.group()
+@main.group(cls=FeatureFlagGroup)
 def restart():
     """Restart entities"""
     pass

--- a/calm/dsl/cli/main.py
+++ b/calm/dsl/cli/main.py
@@ -1,12 +1,12 @@
 from ruamel import yaml
 import click
 import json
-
+import copy
 
 import click_completion
 import click_completion.core
-from click_didyoumean import DYMGroup
 from click_repl import repl
+from prettytable import PrettyTable
 
 # TODO - move providers to separate file
 from calm.dsl.providers import get_provider, get_provider_types
@@ -20,6 +20,7 @@ from calm.dsl.config import get_config
 from calm.dsl.store import Cache
 
 from .version_validator import validate_version
+from .utils import FeatureFlagGroup, highlight_text
 
 CONTEXT_SETTINGS = dict(help_option_names=["-h", "--help"])
 
@@ -27,7 +28,7 @@ click_completion.init()
 LOG = get_logging_handle(__name__)
 
 
-@click.group(context_settings=CONTEXT_SETTINGS)
+@click.group(cls=FeatureFlagGroup, context_settings=CONTEXT_SETTINGS)
 @simple_verbosity_option(LOG)
 @show_trace_option(LOG)
 @click.option(
@@ -73,7 +74,7 @@ Commonly used commands:
         Cache.sync()
 
 
-@main.group(cls=DYMGroup)
+@main.group(cls=FeatureFlagGroup)
 def validate():
     """Validate provider specs"""
     pass
@@ -111,31 +112,87 @@ def validate_provider_spec(spec_file, provider_type):
         raise Exception(ee.message)
 
 
-@main.group(cls=DYMGroup)
+@main.group(cls=FeatureFlagGroup)
 def get():
     """Get various things like blueprints, apps: `get apps` and `get bps` are the primary ones."""
     pass
 
 
-@main.group(cls=DYMGroup)
-def show():
+@main.group(cls=FeatureFlagGroup)
+@click.pass_context
+def show(ctx):
     """Shows the cached data(Dynamic data) etc."""
     pass
 
 
-@main.group(cls=DYMGroup)
+@show.command("commands")
+@click.pass_context
+def show_all_commands(ctx):
+
+    ctx_root = ctx.find_root()
+    root_cmd = ctx_root.command
+
+    commands_queue = []
+    commands_res_list = []
+
+    for subcommand in root_cmd.list_commands(ctx):
+        cmd = root_cmd.get_command(ctx, subcommand)
+
+        if isinstance(cmd, FeatureFlagGroup):
+            commands_queue.append([subcommand, cmd])
+        else:
+            commands_res_list.append(
+                (subcommand, root_cmd.feature_version_map.get(subcommand, "-"))
+            )
+
+    while commands_queue:
+        ele = commands_queue.pop(0)
+        grp = ele.pop(len(ele) - 1)
+
+        for subcommand in grp.list_commands(ctx):
+            cmd = grp.get_command(ctx, subcommand)
+
+            if isinstance(cmd, FeatureFlagGroup):
+                ele_temp = copy.deepcopy(ele)
+                ele_temp.extend([subcommand, cmd])
+                commands_queue.append(ele_temp)
+            else:
+                ele_temp = copy.deepcopy(ele)
+                ele_temp.append(subcommand)
+                commands_res_list.append(
+                    (" ".join(ele_temp), grp.feature_version_map.get(subcommand, "-"))
+                )
+
+    table = PrettyTable()
+    table.field_names = ["COMMAND", "MIN COMMAND VERSION"]
+
+    cmd_list = []
+    for subcommand in commands_res_list:
+        cmd_str = "{} {}".format(ctx_root.command_path, " ".join(subcommand))
+        cmd_list.append(cmd_str)
+
+    for cmd_tuple in commands_res_list:
+        cmd_str = "{} {}".format(ctx_root.command_path, cmd_tuple[0])
+        table.add_row([highlight_text(cmd_str), highlight_text(cmd_tuple[1])])
+
+    # left align the command column
+    table.align["COMMAND"] = "l"
+    click.echo(table)
+
+
+@main.group(cls=FeatureFlagGroup)
 def clear():
     """Clear the data stored in local db: cache, secrets etc."""
     pass
 
 
-@main.group(cls=DYMGroup)
+@main.group(cls=FeatureFlagGroup)
 def init():
     """Initializes the dsl for basic configs and bp directory etc."""
     pass
 
 
-@get.group(cls=DYMGroup)
+@get.group(cls=FeatureFlagGroup)
 def server():
     """Get calm server details"""
     pass
@@ -171,73 +228,73 @@ def get_server_status():
         LOG.info("PC Version: {}".format(pc_version))
 
 
-@main.group(cls=DYMGroup)
+@main.group(cls=FeatureFlagGroup)
 def format():
     """Format blueprint using black"""
     pass
 
 
-@main.group(cls=DYMGroup)
+@main.group(cls=FeatureFlagGroup)
 def compile():
     """Compile blueprint to json / yaml"""
     pass
 
 
-@main.group(cls=DYMGroup)
+@main.group(cls=FeatureFlagGroup)
 def create():
     """Create entities in Calm (blueprint, project) """
     pass
 
 
-@main.group(cls=DYMGroup)
+@main.group(cls=FeatureFlagGroup)
 def delete():
     """Delete entities"""
     pass
 
 
-@main.group(cls=DYMGroup)
+@main.group(cls=FeatureFlagGroup)
 def launch():
     """Launch blueprints to create Apps"""
     pass
 
 
-@main.group(cls=DYMGroup)
+@main.group(cls=FeatureFlagGroup)
 def publish():
     """Publish blueprints to marketplace"""
     pass
 
 
-@main.group(cls=DYMGroup)
+@main.group(cls=FeatureFlagGroup)
 def approve():
     """Approve blueprints in marketplace manager"""
     pass
 
 
-@main.group(cls=DYMGroup)
+@main.group(cls=FeatureFlagGroup)
 def unpublish():
     """Unpublish blueprints from marketplace"""
     pass
 
 
-@main.group(cls=DYMGroup)
+@main.group(cls=FeatureFlagGroup)
 def reject():
     """Reject blueprints from marketplace manager"""
     pass
 
 
-@main.group(cls=DYMGroup)
+@main.group(cls=FeatureFlagGroup)
 def describe():
     """Describe apps, blueprints, projects, accounts"""
     pass
 
 
-@main.group(cls=DYMGroup)
+@main.group(cls=FeatureFlagGroup)
 def run():
     """Run actions in an app"""
     pass
 
 
-@main.group(cls=DYMGroup)
+@main.group(cls=FeatureFlagGroup)
 def watch():
     """Track actions running on apps"""
     pass
@@ -259,13 +316,13 @@ def create_provider_spec(provider_type):
     Provider.create_spec()
 
 
-@main.group(cls=DYMGroup)
+@main.group(cls=FeatureFlagGroup)
 def update():
     """Update entities"""
     pass
 
 
-@main.group(cls=DYMGroup)
+@main.group(cls=FeatureFlagGroup)
 def download():
     """Download entities"""
     pass
@@ -282,7 +339,7 @@ Default type: auto
 )
 
 
-@main.group(cls=DYMGroup, help=completion_cmd_help)
+@main.group(cls=FeatureFlagGroup, help=completion_cmd_help)
 def completion():
     pass
 
@@ -310,7 +367,7 @@ def calmrepl():
     repl(click.get_current_context())
 
 
-@main.group(cls=DYMGroup)
+@main.group(cls=FeatureFlagGroup)
 def set():
     """Sets the entities"""
     pass

--- a/calm/dsl/cli/utils.py
+++ b/calm/dsl/cli/utils.py
@@ -1,7 +1,15 @@
 import click
+import sys
 import importlib.util
 from functools import reduce
 from asciimatics.screen import Screen
+from click_didyoumean import DYMMixin
+from distutils.version import LooseVersion as LV
+
+from calm.dsl.tools import get_logging_handle
+from calm.dsl.store import Version
+
+LOG = get_logging_handle(__name__)
 
 
 def get_states_filter(STATES_CLASS=None, state_key="state", states=[]):
@@ -73,3 +81,56 @@ class Display:
 
 
 display = Display()
+
+
+class FeatureFlagMixin:
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.feature_version_map = dict()
+
+    def command(self, *args, **kwargs):
+        """Behaves the same as `click.Group.command()` except added an
+        `feature_min_version` flag which can be used to warn users if command
+        is not supported setup calm version.
+        """
+
+        feature_min_version = kwargs.pop("feature_min_version", None)
+        if feature_min_version:
+            cmd_name = args[0]
+            self.feature_version_map[cmd_name] = feature_min_version
+
+        return super().command(*args, **kwargs)
+
+    def invoke(self, ctx):
+
+        if not ctx.protected_args:
+            return super(FeatureFlagMixin, self).invoke(ctx)
+
+        cmd_name = ctx.protected_args[0]
+        feature_min_version = self.feature_version_map.get(cmd_name, "")
+        if feature_min_version:
+            calm_version = Version.get_version("Calm")
+            if not calm_version:
+                LOG.error("Calm version not found. Please update cache")
+                sys.exit(-1)
+
+            if LV(calm_version) >= LV(feature_min_version):
+                return super().invoke(ctx)
+
+            else:
+                LOG.warning(
+                    "Please update from {} to {} for using this command.".format(
+                        calm_version, feature_min_version
+                    )
+                )
+                return None
+
+        else:
+            return super().invoke(ctx)
+
+
+class FeatureFlagGroup(FeatureFlagMixin, DYMMixin, click.Group):
+    """click Group that have *did-you-mean* functionality and adds *feature_min_version* paramter to each subcommand
+    which can be used to set minimum calm version for command"""
+
+    pass


### PR DESCRIPTION
1. Added `calm show commands` to show all calm-dsl commands
2. Added FeatureFlagGroup class that adds `min_feature_version` flag to each cli command that can be used to restrict command to be used after particular version