### PR TITLE
fixes #116 support for runbook runtime var without cli prompt

### DIFF
--- a/calm/dsl/cli/runbook_commands.py
+++ b/calm/dsl/cli/runbook_commands.py
@@ -202,13 +202,21 @@ def _compile_runbook_command(runbook_file, out):
     "input_file",
     type=click.Path(exists=True, file_okay=True, dir_okay=False, readable=True),
     required=False,
-    help="Path of input file to get the inputs for runbook",
+    help="Path to python file for runtime editables",
 )
 @click.option("--watch/--no-watch", "-w", default=False, help="Watch scrolling output")
 def _run_runbook_command(
     runbook_name, watch, ignore_runtime_variables, runbook_file=None, input_file=None
 ):
-    """Execute the runbook given by name or runbook file"""
+    """Execute the runbook given by name or runbook file. All runtime variables and default target will be prompted by default. When passing the 'ignore_runtime_editable' flag, no variables will be prompted and all default values will be used. The runbook  default values can be  overridden by passing a Python file via 'input_file'. When passing a Python file, no variables will be prompted.
+
+    \b
+    >: input_file: Python file consisting of variables 'variable_list' and 'default_target'
+    Ex: variable_list = {
+        "value": {"value": <Variable Value>},
+        "name": "<Variable Name>"
+    }
+    default_target: <Endpoint Name>"""
 
     run_runbook_command(
         runbook_name,

--- a/calm/dsl/init/runbook/render.py
+++ b/calm/dsl/init/runbook/render.py
@@ -21,11 +21,7 @@ def render_runbook_template(runbook_name):
     server_config = ContextObj.get_server_config()
     pc_ip = server_config["pc_ip"]
     pc_port = server_config["pc_port"]
-    text = template.render(
-        runbook_name=runbook_name,
-        pc_ip=pc_ip,
-        pc_port=pc_port,
-    )
+    text = template.render(runbook_name=runbook_name, pc_ip=pc_ip, pc_port=pc_port,)
     LOG.info("Success")
 
     return text.strip() + os.linesep

--- a/calm/dsl/tools/validator.py
+++ b/calm/dsl/tools/validator.py
@@ -34,8 +34,10 @@ class validation_error(_Error):
         pschema = yaml.dump(self.schema, default_flow_style=False)
         pinstance = yaml.dump(self.instance, default_flow_style=False)
 
-        return self.message + textwrap.dedent(
-            """
+        return (
+            self.message
+            + textwrap.dedent(
+                """
 
             Failed validating %s at %s:
             %s
@@ -43,14 +45,16 @@ class validation_error(_Error):
             By %r validator in %s at %s:
             %s
             """.rstrip()
-        ) % (
-            self._word_for_instance_in_error_message,
-            _utils.format_as_index(self.relative_path),
-            pinstance,
-            self.validator,
-            self._word_for_schema_in_error_message,
-            _utils.format_as_index(list(self.relative_schema_path)[:-1]),
-            pschema,
+            )
+            % (
+                self._word_for_instance_in_error_message,
+                _utils.format_as_index(self.relative_path),
+                pinstance,
+                self.validator,
+                self._word_for_schema_in_error_message,
+                _utils.format_as_index(list(self.relative_schema_path)[:-1]),
+                pschema,
+            )
         )
 
     __str__ = __unicode__

--- a/tests/sample_runbooks/input_file.py
+++ b/tests/sample_runbooks/input_file.py
@@ -1,0 +1,6 @@
+variable_list = [
+    {"name": "firstname", "value": "kritagya"},
+    {"name": "lastname", "value": "dabi"},
+]
+
+default_target = "test_ep"


### PR DESCRIPTION
Support to read runtime variables from a python file, for runbook runs similar to what we have for blueprint launch calm launch bp <bp_name> --launch_params <launch_param_file>

