### PR TITLE
Display message list on save of BP if in DRAFT state #CALM-14018 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,8 +33,3 @@ jobs:
     - name: Build docker image
       run: |
         make docker
-    - name: Publish docker image
-      if: github.event_name == 'push'
-      run: |
-        docker login -u ${{ secrets.DOCKER_USERNAME }} -p ${{ secrets.DOCKER_PASSWORD }}
-        docker push ntnx/calm-dsl

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,3 +33,8 @@ jobs:
     - name: Build docker image
       run: |
         make docker
+    - name: Publish docker image
+      if: github.event_name == 'push'
+      run: |
+        docker login -u ${{ secrets.DOCKER_USERNAME }} -p ${{ secrets.DOCKER_PASSWORD }}
+        docker push ntnx/calm-dsl


### PR DESCRIPTION
There is already some handling preset to display the messages on the
blueprint entity, but this does not include the messages on sub
entities. These changes pick up the messages from nested sub entities
and try to display it with a meaningful path to the entity that the
validation messages are present on.
<img width="768" alt="Screen Shot 2021-03-26 at 11 21 31 AM" src="https://user-images.githubusercontent.com/3667038/113121165-fcf58880-922f-11eb-87e9-9ba1f2cf7275.png">
