### PR TITLE
Fixes #179

### DIFF
--- a/calm/dsl/api/connection.py
+++ b/calm/dsl/api/connection.py
@@ -316,7 +316,7 @@ class Connection:
                     json.dumps(err, indent=4, separators=(",", ": "))
                 )
             )
-            sys.exit(-1)
+
         return res, err
 
 


### PR DESCRIPTION
Account uuid was getting patched for nutanix accounts by default.
For non-nutanix, account need to send account-uuid in substrate from dsl.

