### PR TITLE
Use ASCENDING order for list_all query

### DIFF
--- a/calm/dsl/api/resource.py
+++ b/calm/dsl/api/resource.py
@@ -104,7 +104,14 @@ class ResourceAPI:
         final_list = []
         offset = 0
         while True:
-            response, err = self.list(params={"length": api_limit, "offset": offset})
+            response, err = self.list(
+                params={
+                    "length": api_limit,
+                    "offset": offset,
+                    "sort_attribute": "_created_timestamp_usecs_",
+                    "sort_order": "ASCENDING",
+                }
+            )
             if not err:
                 response = response.json()
             else:


### PR DESCRIPTION
In the case of concurrent requests, the same entity was coming in multiple batch calls, as the list API is sorted by creation time (descending). Overriding the request to send by ascending order of time creation.
