### PR TITLE
Added support for get_runbook_action and macro in ahv-disk-images

### DIFF
--- a/calm/dsl/builtins/__init__.py
+++ b/calm/dsl/builtins/__init__.py
@@ -9,7 +9,7 @@ from .models.calm_ref import Ref
 from .models.metadata import Metadata, MetadataType
 from .models.credential import basic_cred, secret_cred, CredentialType
 from .models.variable import Variable, setvar, CalmVariable, VariableType
-from .models.action import action, parallel, ActionType
+from .models.action import action, parallel, ActionType, get_runbook_action
 
 from .models.task import Task, CalmTask, TaskType
 
@@ -110,6 +110,7 @@ __all__ = [
     "TaskType",
     "action",
     "ActionType",
+    "get_runbook_action",
     "parallel",
     "Port",
     "port",

--- a/calm/dsl/builtins/models/action.py
+++ b/calm/dsl/builtins/models/action.py
@@ -88,6 +88,19 @@ class action(runbook):
             if gui_display_name and gui_display_name.default != action_name:
                 action_name = gui_display_name.default
 
+        if self.task_target_mapping:
+            # For now it is used to map runbook task's target to bp entities
+            # In runbook, the target will be endpoint. So it will be changed to target_endpoint
+            for _task in self.user_runbook.tasks[1:]:
+                if _task.target_any_local_reference:
+                    _task.exec_target_reference = _task.target_any_local_reference
+                    _task.target_any_local_reference = None
+
+                if _task.name in self.task_target_mapping:
+                    _task.target_any_local_reference = self.task_target_mapping[
+                        _task.name
+                    ]
+
         # Finally create the action
         self.user_action = _action_create(
             **{
@@ -104,3 +117,13 @@ class action(runbook):
 
 class parallel:
     __calm_type__ = "parallel"
+
+
+def get_runbook_action(runbook_obj, task_target_mapping={"abhijeet": "singh"}):
+    """
+    Get action from the runbook object
+    """
+
+    user_func = runbook_obj.user_func
+    action_obj = action(user_func, task_target_mapping=task_target_mapping)
+    return action_obj

--- a/calm/dsl/builtins/models/action.py
+++ b/calm/dsl/builtins/models/action.py
@@ -88,18 +88,32 @@ class action(runbook):
             if gui_display_name and gui_display_name.default != action_name:
                 action_name = gui_display_name.default
 
-        if self.task_target_mapping:
-            # For now it is used to map runbook task's target to bp entities
-            # In runbook, the target will be endpoint. So it will be changed to target_endpoint
-            for _task in self.user_runbook.tasks[1:]:
-                if _task.target_any_local_reference:
-                    _task.exec_target_reference = _task.target_any_local_reference
-                    _task.target_any_local_reference = None
+        # Case for imported runbooks in blueprints
+        if self.imported_action:
 
-                if _task.name in self.task_target_mapping:
-                    _task.target_any_local_reference = self.task_target_mapping[
-                        _task.name
-                    ]
+            # Mapping is compulsory for profile actions
+            if self.task_target_mapping:
+                # For now it is used to map runbook task's target to bp entities for PROFILE
+                # In runbook, the target will be endpoint. So it will be changed to target_endpoint
+                for _task in self.user_runbook.tasks[1:]:
+                    if _task.target_any_local_reference:
+                        _task.exec_target_reference = _task.target_any_local_reference
+                        _task.target_any_local_reference = None
+
+                    if _task.name in self.task_target_mapping:
+                        _task.target_any_local_reference = self.task_target_mapping[
+                            _task.name
+                        ]
+
+            # Non-Profile actions
+            else:
+                for _task in self.user_runbook.tasks[1:]:
+                    if (
+                        _task.target_any_local_reference
+                        and _task.target_any_local_reference.kind == "app_endpoint"
+                    ):
+                        _task.exec_target_reference = _task.target_any_local_reference
+                        _task.target_any_local_reference = self.task_target
 
         # Finally create the action
         self.user_action = _action_create(
@@ -119,11 +133,13 @@ class parallel:
     __calm_type__ = "parallel"
 
 
-def get_runbook_action(runbook_obj, task_target_mapping={"abhijeet": "singh"}):
+def get_runbook_action(runbook_obj, task_target_mapping={}):
     """
     Get action from the runbook object
     """
 
     user_func = runbook_obj.user_func
-    action_obj = action(user_func, task_target_mapping=task_target_mapping)
+    action_obj = action(
+        user_func, task_target_mapping=task_target_mapping, imported_action=True
+    )
     return action_obj

--- a/calm/dsl/builtins/models/action.py
+++ b/calm/dsl/builtins/models/action.py
@@ -174,13 +174,11 @@ class parallel:
     __calm_type__ = "parallel"
 
 
-def get_runbook_action(runbook_obj, task_target_mapping={}):
+def get_runbook_action(runbook_obj, targets={}):
     """
     Get action from the runbook object
     """
 
     user_func = runbook_obj.user_func
-    action_obj = action(
-        user_func, task_target_mapping=task_target_mapping, imported_action=True
-    )
+    action_obj = action(user_func, task_target_mapping=targets, imported_action=True)
     return action_obj

--- a/calm/dsl/builtins/models/ahv_vm_disk.py
+++ b/calm/dsl/builtins/models/ahv_vm_disk.py
@@ -44,31 +44,37 @@ class AhvDiskType(EntityType):
             image_name = image_ref.get("name")
             device_type = cdict["device_properties"].get("device_type")
 
-            image_cache_data = Cache.get_entity_data(
-                entity_type=CACHE.ENTITY.AHV_DISK_IMAGE,
-                name=image_name,
-                image_type=IMAGE_TYPE_MAP[device_type],
-                account_uuid=account_uuid,
-            )
-            if not image_cache_data:
-                LOG.debug(
-                    "Ahv Disk Image (name = '{}') not found in registered nutanix_pc account (uuid = '{}') in project (name = '{}')".format(
-                        image_name, account_uuid, project["name"]
-                    )
+            if image_name.startswith("@@{") and image_name.endswith("}@@"):
+                cdict["data_source_reference"] = {
+                    "kind": "image",
+                    "uuid": image_name,
+                }
+            else:
+                image_cache_data = Cache.get_entity_data(
+                    entity_type=CACHE.ENTITY.AHV_DISK_IMAGE,
+                    name=image_name,
+                    image_type=IMAGE_TYPE_MAP[device_type],
+                    account_uuid=account_uuid,
                 )
-                LOG.error(
-                    "Ahv Disk Image {} of type {} not found. Please run: calm update cache".format(
-                        image_name, IMAGE_TYPE_MAP[device_type]
+                if not image_cache_data:
+                    LOG.debug(
+                        "Ahv Disk Image (name = '{}') not found in registered nutanix_pc account (uuid = '{}') in project (name = '{}')".format(
+                            image_name, account_uuid, project["name"]
+                        )
                     )
-                )
-                sys.exit(-1)
+                    LOG.error(
+                        "Ahv Disk Image {} of type {} not found. Please run: calm update cache".format(
+                            image_name, IMAGE_TYPE_MAP[device_type]
+                        )
+                    )
+                    sys.exit(-1)
 
-            image_uuid = image_cache_data.get("uuid", "")
-            cdict["data_source_reference"] = {
-                "kind": "image",
-                "name": image_name,
-                "uuid": image_uuid,
-            }
+                image_uuid = image_cache_data.get("uuid", "")
+                cdict["data_source_reference"] = {
+                    "kind": "image",
+                    "name": image_name,
+                    "uuid": image_uuid,
+                }
 
         return cdict
 

--- a/calm/dsl/builtins/models/entity.py
+++ b/calm/dsl/builtins/models/entity.py
@@ -66,6 +66,8 @@ class EntityDict(OrderedDict):
 
             elif isinstance(type(value), DescriptorType):
                 ValidatorType = None
+                # Set action_name attribute in action object
+                setattr(value, "action_name", name)
             is_array = False
 
         if ValidatorType is not None:

--- a/calm/dsl/builtins/models/runbook.py
+++ b/calm/dsl/builtins/models/runbook.py
@@ -58,7 +58,7 @@ class runbook(metaclass=DescriptorType):
     runbook descriptor
     """
 
-    def __init__(self, user_func, task_target_mapping=None):
+    def __init__(self, user_func, task_target_mapping={}, imported_action=False):
         """
         A decorator for generating runbooks from a function definition.
         Args:
@@ -74,8 +74,10 @@ class runbook(metaclass=DescriptorType):
         self.user_runbook = None
         self.task_target = None
 
-        # Will be used in actions
+        # Will be used in runbooks imported to blueprint actions
         self.task_target_mapping = task_target_mapping
+        self.imported_action = imported_action
+
         if self.__class__ == runbook:
             self.__get__()
 

--- a/calm/dsl/builtins/models/runbook.py
+++ b/calm/dsl/builtins/models/runbook.py
@@ -58,7 +58,7 @@ class runbook(metaclass=DescriptorType):
     runbook descriptor
     """
 
-    def __init__(self, user_func, task_target_mapping={}, imported_action=False):
+    def __init__(self, user_func):
         """
         A decorator for generating runbooks from a function definition.
         Args:
@@ -73,10 +73,6 @@ class runbook(metaclass=DescriptorType):
         self.user_func = user_func
         self.user_runbook = None
         self.task_target = None
-
-        # Will be used in runbooks imported to blueprint actions
-        self.task_target_mapping = task_target_mapping
-        self.imported_action = imported_action
 
         if self.__class__ == runbook:
             self.__get__()

--- a/calm/dsl/builtins/models/runbook.py
+++ b/calm/dsl/builtins/models/runbook.py
@@ -58,7 +58,7 @@ class runbook(metaclass=DescriptorType):
     runbook descriptor
     """
 
-    def __init__(self, user_func):
+    def __init__(self, user_func, task_target_mapping=None):
         """
         A decorator for generating runbooks from a function definition.
         Args:
@@ -73,6 +73,9 @@ class runbook(metaclass=DescriptorType):
         self.user_func = user_func
         self.user_runbook = None
         self.task_target = None
+
+        # Will be used in actions
+        self.task_target_mapping = task_target_mapping
         if self.__class__ == runbook:
             self.__get__()
 

--- a/examples/AHV_MACRO_BLUEPRINT/blueprint.py
+++ b/examples/AHV_MACRO_BLUEPRINT/blueprint.py
@@ -1,0 +1,87 @@
+"""
+This blueprint uses macro in nic and disk
+"""
+
+import os  # no_qa
+
+from calm.dsl.builtins import *  # no_qa
+
+
+# Secret Variables
+CRED_USERNAME = read_local_file("cred_username")
+CRED_PASSWORD = read_local_file("cred_password")
+
+
+class Service1(Service):
+    """Sample Service"""
+
+    # disk image uuid to be used in disk image
+    Custom_disk_uuid = CalmVariable.Simple.string(
+        "e7b96d85-f41b-40a1-bd23-310b7de14eb1"
+    )
+
+
+class Package1(Package):
+    """Sample package"""
+
+    services = [ref(Service1)]
+
+
+class VmResources(AhvVmResources):
+
+    memory = 2
+    vCPUs = 2
+    cores_per_vCPU = 2
+    disks = [
+        AhvVmDisk.Disk.Scsi.cloneFromImageService(
+            "@@{Service1.Custom_disk_uuid}@@", bootable=True
+        )
+    ]
+    nics = [AhvVmNic.NormalNic.ingress("@@{custom_nic.uuid}@@")]
+
+
+class VMSubstrate(Substrate):
+    """Sample Substrate"""
+
+    provider_spec = ahv_vm(
+        name="vm-@@{calm_array_index}@@-@@{calm_time}@@", resources=VmResources
+    )
+
+    @action
+    def __pre_create__():
+        CalmTask.SetVariable.escript(
+            name="Pre_create task1",
+            filename=os.path.join("scripts", "pre_create_script.py"),
+            target=ref(VMSubstrate),
+            variables=["custom_nic"],
+        )
+
+
+class MacroBlueprintDeployment(Deployment):
+    """Sample Deployment"""
+
+    packages = [ref(Package1)]
+    substrate = ref(VMSubstrate)
+
+
+class MacroBlueprintProfile(Profile):
+    """Sample Profile"""
+
+    foo1 = CalmVariable.Simple("bar1", runtime=True)
+    foo2 = CalmVariable.Simple("bar2", runtime=True)
+    deployments = [MacroBlueprintDeployment]
+
+    @action
+    def test_profile_action():
+        """Sample description for a profile action"""
+        CalmTask.Exec.ssh(name="Task5", script='echo "Hello"', target=ref(Service1))
+
+
+class MacroBlueprint(Blueprint):
+    """Blueprint using macro in disk and nics"""
+
+    services = [Service1]
+    packages = [Package1]
+    substrates = [VMSubstrate]
+    profiles = [MacroBlueprintProfile]
+    credentials = [basic_cred(CRED_USERNAME, CRED_PASSWORD, default=True)]

--- a/examples/AHV_MACRO_BLUEPRINT/blueprint.py
+++ b/examples/AHV_MACRO_BLUEPRINT/blueprint.py
@@ -5,6 +5,7 @@ This blueprint uses macro in nic and disk
 import os  # no_qa
 
 from calm.dsl.builtins import *  # no_qa
+from examples.AHV_MACRO_BLUEPRINT.sample_runbook import DslSetVariableTask
 
 
 # Secret Variables
@@ -70,6 +71,16 @@ class MacroBlueprintProfile(Profile):
     foo1 = CalmVariable.Simple("bar1", runtime=True)
     foo2 = CalmVariable.Simple("bar2", runtime=True)
     deployments = [MacroBlueprintDeployment]
+
+    # For profile, actions task_target_mapping is compulsory
+    http_task_action = get_runbook_action(
+        DslSetVariableTask,
+        task_target_mapping={
+            "Task1": ref(Service1),
+            "Task2": ref(Service1),
+            "Task3": ref(Service1),
+        }
+    )
 
     @action
     def test_profile_action():

--- a/examples/AHV_MACRO_BLUEPRINT/blueprint.py
+++ b/examples/AHV_MACRO_BLUEPRINT/blueprint.py
@@ -5,7 +5,7 @@ This blueprint uses macro in nic and disk
 import os  # no_qa
 
 from calm.dsl.builtins import *  # no_qa
-from examples.AHV_MACRO_BLUEPRINT.sample_runbook import DslSetVariableTask
+from examples.AHV_MACRO_BLUEPRINT.sample_runbook import DslSetVariableRunbook
 
 
 # Secret Variables
@@ -74,8 +74,8 @@ class MacroBlueprintProfile(Profile):
 
     # For profile, actions task_target_mapping is compulsory
     http_task_action = get_runbook_action(
-        DslSetVariableTask,
-        task_target_mapping={
+        DslSetVariableRunbook,
+        targets={
             "Task1": ref(Service1),
             "Task2": ref(Service1),
             "Task3": ref(Service1),

--- a/examples/AHV_MACRO_BLUEPRINT/blueprint_em.py
+++ b/examples/AHV_MACRO_BLUEPRINT/blueprint_em.py
@@ -6,7 +6,7 @@ import os  # no_qa
 import json
 
 from calm.dsl.builtins import *  # no_qa
-from examples.AHV_MACRO_BLUEPRINT.sample_runbook import DslSetVariableTask
+from examples.AHV_MACRO_BLUEPRINT.sample_runbook import DslSetVariableRunbook
 
 
 # Secret Variables
@@ -26,7 +26,7 @@ class Service1(Service):
     )
 
     # For profile, actions task_target_mapping is compulsory
-    http_task_action2 = get_runbook_action(DslSetVariableTask)
+    http_task_action2 = get_runbook_action(DslSetVariableRunbook)
 
 
 class Package1(Package):
@@ -68,8 +68,8 @@ class MacroBlueprintProfile(Profile):
 
     # For profile, actions task_target_mapping is compulsory
     http_task_action = get_runbook_action(
-        DslSetVariableTask,
-        task_target_mapping={
+        DslSetVariableRunbook,
+        targets={
             "Task1": ref(Service1),
             "Task2": ref(Service1),
             "Task3": ref(Service1),

--- a/examples/AHV_MACRO_BLUEPRINT/blueprint_em.py
+++ b/examples/AHV_MACRO_BLUEPRINT/blueprint_em.py
@@ -1,0 +1,93 @@
+"""
+This blueprint uses macro in nic and disk
+"""
+
+import os  # no_qa
+import json
+
+from calm.dsl.builtins import *  # no_qa
+from examples.AHV_MACRO_BLUEPRINT.sample_runbook import DslSetVariableTask
+
+
+# Secret Variables
+CRED_USERNAME = read_local_file("cred_username")
+CRED_PASSWORD = read_local_file("cred_password")
+DNS_SERVER = read_local_file(".tests/dns_server")
+DSL_CONFIG = json.loads(read_local_file(".tests/config.json"))
+TEST_PC_IP = DSL_CONFIG["EXISTING_MACHINE"]["IP_1"]
+
+
+class Service1(Service):
+    """Sample Service"""
+
+    # disk image uuid to be used in disk image
+    Custom_disk_uuid = CalmVariable.Simple.string(
+        "e7b96d85-f41b-40a1-bd23-310b7de14eb1"
+    )
+
+    # For profile, actions task_target_mapping is compulsory
+    http_task_action2 = get_runbook_action(DslSetVariableTask)
+
+
+class Package1(Package):
+    """Sample package"""
+
+    services = [ref(Service1)]
+
+
+class ExistingVM(Substrate):
+    """CentOS VM"""
+
+    provider_type = "EXISTING_VM"
+    provider_spec = provider_spec({"address": TEST_PC_IP})
+    readiness_probe = {
+        "disabled": False,
+        "delay_secs": "0",
+        "connection_type": "SSH",
+        "connection_port": 22,
+    }
+
+    @action
+    def __pre_create__():
+        CalmTask.Exec.escript(name="Pre Create Task", script="print 'Hello!'")
+
+
+class MacroBlueprintDeployment(Deployment):
+    """Sample Deployment"""
+
+    packages = [ref(Package1)]
+    substrate = ref(ExistingVM)
+
+
+class MacroBlueprintProfile(Profile):
+    """Sample Profile"""
+
+    foo1 = CalmVariable.Simple("bar1", runtime=True)
+    foo2 = CalmVariable.Simple("bar2", runtime=True)
+    deployments = [MacroBlueprintDeployment]
+
+    # For profile, actions task_target_mapping is compulsory
+    http_task_action = get_runbook_action(
+        DslSetVariableTask,
+        task_target_mapping={
+            "Task1": ref(Service1),
+            "Task2": ref(Service1),
+            "Task3": ref(Service1),
+        },
+    )
+
+    @action
+    def test_profile_action():
+        """Sample description for a profile action"""
+        CalmTask.Exec.ssh(name="Task5", script='echo "Hello"', target=ref(Service1))
+        Service1.http_task_action2()
+
+
+class MacroBlueprintEM(Blueprint):
+    """Blueprint using macro in disk and nics"""
+
+    services = [Service1]
+    packages = [Package1]
+    substrates = [ExistingVM]
+    profiles = [MacroBlueprintProfile]
+    credentials = [basic_cred(CRED_USERNAME, CRED_PASSWORD, default=True)]

--- a/examples/AHV_MACRO_BLUEPRINT/sample_runbook.py
+++ b/examples/AHV_MACRO_BLUEPRINT/sample_runbook.py
@@ -1,0 +1,18 @@
+"""
+Calm Runbook Sample for set variable task
+"""
+
+from calm.dsl.runbooks import runbook, ref
+from calm.dsl.runbooks import RunbookTask as Task
+from calm.dsl.runbooks import CalmEndpoint as Endpoint
+
+
+@runbook
+def DslSetVariableTask():
+    "Runbook example with Set Variable Tasks"
+
+    Task.SetVariable.escript(name="Task1", script="print 'var1=test'", variables=["var1"])
+    Task.SetVariable.ssh(
+        name="Task2", script="print 'var2=test_var2'", variables=["var2"], target=ref(Endpoint.use_existing("efv"))
+    )
+    Task.Exec.escript(name="Task3", script="print '@@{var1}@@ @@{var2}@@'")

--- a/examples/AHV_MACRO_BLUEPRINT/sample_runbook.py
+++ b/examples/AHV_MACRO_BLUEPRINT/sample_runbook.py
@@ -13,6 +13,6 @@ def DslSetVariableTask():
 
     Task.SetVariable.escript(name="Task1", script="print 'var1=test'", variables=["var1"])
     Task.SetVariable.ssh(
-        name="Task2", script="print 'var2=test_var2'", variables=["var2"], target=ref(Endpoint.use_existing("efv"))
+        name="Task2", script="echo 'var2=test_var2'", variables=["var2"], target=ref(Endpoint.use_existing("efv"))
     )
     Task.Exec.escript(name="Task3", script="print '@@{var1}@@ @@{var2}@@'")

--- a/examples/AHV_MACRO_BLUEPRINT/sample_runbook_2.py
+++ b/examples/AHV_MACRO_BLUEPRINT/sample_runbook_2.py
@@ -1,7 +1,6 @@
 """
 Calm Runbook Sample for set variable task
 """
-import os
 
 from calm.dsl.runbooks import runbook, ref
 from calm.dsl.runbooks import RunbookTask as Task
@@ -12,8 +11,5 @@ from calm.dsl.runbooks import CalmEndpoint as Endpoint
 def DslSetVariableRunbook():
     "Runbook example with Set Variable Tasks"
 
-    Task.SetVariable.escript(name="Task1", filename=os.path.join("scripts", "set_variable_task1_script.py"), variables=["var1"])
-    Task.SetVariable.ssh(
-        name="Task2", filename=os.path.join("scripts", "set_variable_task2_script.sh"), variables=["var2"], target=ref(Endpoint.use_existing("linux_bedag"))
-    )
+    Task.SetVariable.escript(name="Task1", script="print 'var1=test'", variables=["var1"])
     Task.Exec.escript(name="Task3", script="print '@@{var1}@@ @@{var2}@@'")

--- a/examples/AHV_MACRO_BLUEPRINT/scripts/pre_create_script.py
+++ b/examples/AHV_MACRO_BLUEPRINT/scripts/pre_create_script.py
@@ -1,0 +1,1 @@
+print 'custom_nic={"kind": "subnet", "uuid": "6db195b8-438a-e301-6ec7-bea88ee197f1"}'

--- a/examples/AHV_MACRO_BLUEPRINT/scripts/set_variable_task1_script.py
+++ b/examples/AHV_MACRO_BLUEPRINT/scripts/set_variable_task1_script.py
@@ -1,0 +1,1 @@
+print 'var1=test'

--- a/examples/AHV_MACRO_BLUEPRINT/scripts/set_variable_task2_script.sh
+++ b/examples/AHV_MACRO_BLUEPRINT/scripts/set_variable_task2_script.sh
@@ -1,0 +1,1 @@
+echo 'var2=test_var2'

--- a/tests/existing_vm_example/test_existing_vm_bp.py
+++ b/tests/existing_vm_example/test_existing_vm_bp.py
@@ -12,6 +12,7 @@ from calm.dsl.builtins import CalmVariable
 from calm.dsl.builtins import Service, Package, Substrate
 from calm.dsl.builtins import Deployment, Profile, Blueprint
 from calm.dsl.builtins import provider_spec, read_local_file
+from tests.sample_runbooks.http_task import DslHTTPTask
 
 DNS_SERVER = read_local_file(".tests/dns_server")
 
@@ -374,25 +375,6 @@ class DefaultProfile(Profile):
 
     @action
     def test_profile_action():
-        var1 = CalmVariable.Simple(  # noqa
-            "var1_val",
-            label="var1_label",
-            regex="^[a-zA-Z0-9_]+$",
-            validate_regex=True,
-            runtime=True,
-        )
-        var2 = CalmVariable.Simple.Secret(  # noqa
-            "var2_val",
-            label="var2_label",
-            regex="^[a-zA-Z0-9_]+$",
-            validate_regex=True,
-            is_hidden=True,
-            is_mandatory=True,
-        )
-        CalmTask.Exec.ssh(
-            name="Task5", filename="scripts/sample_script.sh", target=ref(MySQLService)
-        )
-        PHPService.test_action(name="Task6")
         CalmTask.HTTP.get(
             "https://jsonplaceholder.typicode.com/posts/1",
             credential=DefaultCred,
@@ -405,69 +387,6 @@ class DefaultProfile(Profile):
             name="Test HTTP Task Get",
             target=ref(MySQLService),
         )
-        CalmTask.HTTP.post(
-            "https://jsonplaceholder.typicode.com/posts",
-            body=json.dumps({"id": 1, "title": "foo", "body": "bar", "userId": 1}),
-            headers={"Content-Type": "application/json"},
-            cred=ref(DefaultCred),
-            content_type="application/json",
-            verify=True,
-            status_mapping={200: True},
-            response_paths={"foo_title": "$.title"},
-            name="Test HTTP Task Post",
-            target=ref(MySQLService),
-        )
-        CalmTask.HTTP.put(
-            "https://jsonplaceholder.typicode.com/posts/1",
-            body=json.dumps({"id": 1, "title": "foo", "body": "bar", "userId": 1}),
-            headers={"Content-Type": "application/json"},
-            content_type="application/json",
-            verify=True,
-            status_mapping={200: True},
-            response_paths={"foo_title": "$.title"},
-            name="Test HTTP Task Put",
-            target=ref(MySQLService),
-        )
-        CalmTask.HTTP.delete(
-            "https://jsonplaceholder.typicode.com/posts/1",
-            headers={"Content-Type": "application/json"},
-            content_type="application/json",
-            verify=True,
-            status_mapping={200: True},
-            name="Test HTTP Task Delete",
-            target=ref(MySQLService),
-        )
-        CalmTask.HTTP(
-            "PUT",
-            "https://jsonplaceholder.typicode.com/posts/1",
-            body=json.dumps({"id": 1, "title": "foo", "body": "bar", "userId": 1}),
-            headers={"Content-Type": "application/json"},
-            content_type="application/json",
-            verify=True,
-            status_mapping={200: True},
-            response_paths={"foo_title": "$.title"},
-            name="Test HTTP Task",
-            target=ref(MySQLService),
-        )
-        with parallel():
-            CalmTask.Exec.escript(
-                "print 'Hello World!'", name="Test Escript", target=ref(MySQLService)
-            )
-            CalmTask.SetVariable.escript(
-                script="print 'var1=test'",
-                name="Test Setvar Escript",
-                variables=["var1"],
-                target=ref(MySQLService),
-            )
-            CalmTask.SetVariable.ssh(
-                filename="scripts/sample_script.sh",
-                name="Test Setvar SSH",
-                variables=["var2"],
-                target=ref(MySQLService),
-            )
-        CalmTask.Scaling.scale_out(1, target=ref(LampDeployment), name="Scale out Lamp")
-        CalmTask.Delay(delay_seconds=60, target=ref(MySQLService), name="Delay")
-        CalmTask.Scaling.scale_in(1, target=LampDeployment, name="Scale in Lamp")
 
 
 class ExistingVMBlueprint(Blueprint):
@@ -511,3 +430,8 @@ def test_json():
 
     known_json = json.load(open(file_path))
     assert generated_json == known_json
+
+
+import ipdb
+
+ipdb.set_trace()

--- a/tests/existing_vm_example/test_existing_vm_bp.py
+++ b/tests/existing_vm_example/test_existing_vm_bp.py
@@ -12,7 +12,6 @@ from calm.dsl.builtins import CalmVariable
 from calm.dsl.builtins import Service, Package, Substrate
 from calm.dsl.builtins import Deployment, Profile, Blueprint
 from calm.dsl.builtins import provider_spec, read_local_file
-from tests.sample_runbooks.http_task import DslHTTPTask
 
 DNS_SERVER = read_local_file(".tests/dns_server")
 
@@ -375,6 +374,25 @@ class DefaultProfile(Profile):
 
     @action
     def test_profile_action():
+        var1 = CalmVariable.Simple(  # noqa
+            "var1_val",
+            label="var1_label",
+            regex="^[a-zA-Z0-9_]+$",
+            validate_regex=True,
+            runtime=True,
+        )
+        var2 = CalmVariable.Simple.Secret(  # noqa
+            "var2_val",
+            label="var2_label",
+            regex="^[a-zA-Z0-9_]+$",
+            validate_regex=True,
+            is_hidden=True,
+            is_mandatory=True,
+        )
+        CalmTask.Exec.ssh(
+            name="Task5", filename="scripts/sample_script.sh", target=ref(MySQLService)
+        )
+        PHPService.test_action(name="Task6")
         CalmTask.HTTP.get(
             "https://jsonplaceholder.typicode.com/posts/1",
             credential=DefaultCred,
@@ -387,6 +405,69 @@ class DefaultProfile(Profile):
             name="Test HTTP Task Get",
             target=ref(MySQLService),
         )
+        CalmTask.HTTP.post(
+            "https://jsonplaceholder.typicode.com/posts",
+            body=json.dumps({"id": 1, "title": "foo", "body": "bar", "userId": 1}),
+            headers={"Content-Type": "application/json"},
+            cred=ref(DefaultCred),
+            content_type="application/json",
+            verify=True,
+            status_mapping={200: True},
+            response_paths={"foo_title": "$.title"},
+            name="Test HTTP Task Post",
+            target=ref(MySQLService),
+        )
+        CalmTask.HTTP.put(
+            "https://jsonplaceholder.typicode.com/posts/1",
+            body=json.dumps({"id": 1, "title": "foo", "body": "bar", "userId": 1}),
+            headers={"Content-Type": "application/json"},
+            content_type="application/json",
+            verify=True,
+            status_mapping={200: True},
+            response_paths={"foo_title": "$.title"},
+            name="Test HTTP Task Put",
+            target=ref(MySQLService),
+        )
+        CalmTask.HTTP.delete(
+            "https://jsonplaceholder.typicode.com/posts/1",
+            headers={"Content-Type": "application/json"},
+            content_type="application/json",
+            verify=True,
+            status_mapping={200: True},
+            name="Test HTTP Task Delete",
+            target=ref(MySQLService),
+        )
+        CalmTask.HTTP(
+            "PUT",
+            "https://jsonplaceholder.typicode.com/posts/1",
+            body=json.dumps({"id": 1, "title": "foo", "body": "bar", "userId": 1}),
+            headers={"Content-Type": "application/json"},
+            content_type="application/json",
+            verify=True,
+            status_mapping={200: True},
+            response_paths={"foo_title": "$.title"},
+            name="Test HTTP Task",
+            target=ref(MySQLService),
+        )
+        with parallel():
+            CalmTask.Exec.escript(
+                "print 'Hello World!'", name="Test Escript", target=ref(MySQLService)
+            )
+            CalmTask.SetVariable.escript(
+                script="print 'var1=test'",
+                name="Test Setvar Escript",
+                variables=["var1"],
+                target=ref(MySQLService),
+            )
+            CalmTask.SetVariable.ssh(
+                filename="scripts/sample_script.sh",
+                name="Test Setvar SSH",
+                variables=["var2"],
+                target=ref(MySQLService),
+            )
+        CalmTask.Scaling.scale_out(1, target=ref(LampDeployment), name="Scale out Lamp")
+        CalmTask.Delay(delay_seconds=60, target=ref(MySQLService), name="Delay")
+        CalmTask.Scaling.scale_in(1, target=LampDeployment, name="Scale in Lamp")
 
 
 class ExistingVMBlueprint(Blueprint):
@@ -430,8 +511,3 @@ def test_json():
 
     known_json = json.load(open(file_path))
     assert generated_json == known_json
-
-
-import ipdb
-
-ipdb.set_trace()


### PR DESCRIPTION
Users can use get_runbook_action to import existing runbooks (with limited tasks) to blueprints at service/profile levels.
Users can also supply macro in the ahv disk image.