### PR TITLE
Black version changes and build changes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,19 +9,21 @@ on:
 
 jobs:
   build:
-
-    runs-on: [ubuntu-latest]
-
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        python-version: ['3.6', '3.7', '3.8', '3.9']
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python 3.7
-      uses: actions/setup-python@v1
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v3
       with:
-        python-version: 3.7
+        python-version: ${{ matrix.python-version }}
     - name: black
       uses: psf/black@stable # Exclude list is not honored - https://github.com/psf/black/issues/1584
       with:
-        version: "22.3.0"
+        version: "22.6.0"
     - name: Setup env
       run: |
         python -m pip install --upgrade pip
@@ -41,7 +43,7 @@ jobs:
         image: ntnx/calm-dsl
         run: calm
     - name: Publish docker image
-      if: ${{ github.event_name == 'push' && github.repository == 'nutanix/calm-dsl'}}
+      if: ${{ github.event_name == 'push' && github.repository == 'nutanix/calm-dsl' && ${{ matrix.os }} == '3.9'}}
       run: |
         docker login -u ${{ secrets.DOCKER_USERNAME }} -p ${{ secrets.DOCKER_PASSWORD }}
         docker push ntnx/calm-dsl

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,7 +43,7 @@ jobs:
         image: ntnx/calm-dsl
         run: calm
     - name: Publish docker image
-      if: ${{ github.event_name == 'push' && github.repository == 'nutanix/calm-dsl' && ${{ matrix.os }} == '3.9'}}
+      if: ${{ github.event_name == 'push' && github.repository == 'nutanix/calm-dsl' && matrix.os == '3.9'}}
       run: |
         docker login -u ${{ secrets.DOCKER_USERNAME }} -p ${{ secrets.DOCKER_PASSWORD }}
         docker push ntnx/calm-dsl

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,14 +14,14 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python 3.7
+    - name: Set up Python 3.6
       uses: actions/setup-python@v1
       with:
-        python-version: 3.7
+        python-version: 3.6
     - name: black
-      uses: psf/black@stable # Exclude list is not honored - https://github.com/psf/black/issues/1584
+      uses: psf/black@stable
       with:
-        version: "21.4b1"
+        version: "22.6.0"
     - name: Setup env
       run: |
         python -m pip install --upgrade pip

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,8 @@ ENV BUILD_PACKAGES="\
         openssl-dev \
         libxml2-dev \
         jpeg-dev \
+        sqlite-dev \
+        ncurses-dev \
 	"
 
 # Install build packages for building from source

--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,8 @@ run:
 
 _init_centos:
 	# Lets get python3 in
-	rpm -q epel-release || sudo yum -y install epel-release openssl-devel
+	rpm -q epel-release || sudo yum -y install epel-release
+	sudo yum -y install openssl-devel sqlite-devel ncurses-devel
 	# Not needed: This has a modern git
 	# rpm -q wandisco-git-release || sudo yum install -y http://opensource.wandisco.com/centos/7/git/x86_64/wandisco-git-release-7-2.noarch.rpm || :
 	#sudo yum update -y git || :

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ ruamel.yaml==0.16.12
 jinja2==3.0.3
 jsonref==0.2
 bidict==0.18.0
-requests==2.27.0
+requests==2.27.0    # version greater than this will require python >= 3.7
 requests_toolbelt==0.9.1
 docopt==0.6.2
 PTable==0.9.2
@@ -16,10 +16,10 @@ jsonschema==3.2.0
 anytree==2.8.0
 asciimatics>==1.13.0
 peewee==3.10.0
-pycryptodome==3.15.0
+pycryptodome==3.15.0    # version greater than this will require python >= 3.7
 scrypt==0.8.20
 schema==0.7.1
 colorlog==5.0.1
 black==22.6.0
-importlib-metadata==4.6.0
+importlib-metadata==4.6.0   # version greater than this will require python >= 3.7
 backports.zoneinfo==0.2.1;python_version<"3.9"

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,11 +2,11 @@ ruamel.yaml==0.16.12
 jinja2==3.0.3
 jsonref==0.2
 bidict==0.18.0
-requests==2.21.0
+requests==2.27.0
 requests_toolbelt==0.9.1
 docopt==0.6.2
 PTable==0.9.2
-Click==8.1.2
+Click==8.0.4    # version greater than this will require python >= 3.7
 click_completion==0.5.2
 click-didyoumean==0.0.3
 click-repl==0.2.0
@@ -16,10 +16,10 @@ jsonschema==3.2.0
 anytree==2.8.0
 asciimatics>==1.13.0
 peewee==3.10.0
-pycryptodome==3.9.0
-scrypt==0.8.13
+pycryptodome==3.15.0
+scrypt==0.8.20
 schema==0.7.1
 colorlog==5.0.1
-black==22.3.0
-importlib-metadata==4.0.1
+black==22.6.0
+importlib-metadata==4.6.0
 backports.zoneinfo==0.2.1;python_version<"3.9"

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ click_completion==0.5.2
 click-didyoumean==0.0.3
 click-repl==0.2.0
 colorama==0.4.1
-arrow==0.13.1
+arrow==0.15.1
 jsonschema==3.2.0
 anytree==2.8.0
 asciimatics>==1.13.0


### PR DESCRIPTION
Use black module released version.
Use click version that is compatible with python3.6.
Update request module also to 2.27.0, as older version doesn't support latest boto3 lib
Updated dependent pycryptodome and scrypt module version