### PR TITLE
Use python 3.7 for release containers

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,10 +14,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python 3.6
-      uses: actions/setup-python@v1
+    - name: Set up Python 3.7
+      uses: actions/setup-python@v3
       with:
-        python-version: 3.6
+        python-version: 3.7
     - name: black
       uses: psf/black@stable
       with:


### PR DESCRIPTION
(cherry picked from commit 2a58010fa40070f13f0e3b23904373259e5bbcf5)