### PR TITLE
Decompile fixes for vtpm_config attribute

### DIFF
--- a/calm/dsl/providers/plugins/ahv_vm/ahv_vm_provider_spec.yaml.jinja2
+++ b/calm/dsl/providers/plugins/ahv_vm/ahv_vm_provider_spec.yaml.jinja2
@@ -461,7 +461,6 @@ properties:
     items:
       {{ ahvSerialPort() | indent(6) }}
   vtpm_config:
-    x-calm-dsl-min-version: 4.1.0
     {{ ahvVtpmConfig() | indent(4) }}
 
 {%- endmacro %}

--- a/calm/dsl/providers/plugins/ahv_vm/ahv_vm_provider_spec.yaml.jinja2
+++ b/calm/dsl/providers/plugins/ahv_vm/ahv_vm_provider_spec.yaml.jinja2
@@ -96,6 +96,19 @@ properties:
 
 {%- endmacro %}
 
+{% macro ahvVtpmConfig() -%}
+
+title: AHV Vtpm Configuration
+type: [object, "null"]
+properties:
+  type:
+    type: string
+  vtpm_enabled:
+    type: boolean
+    default: false
+
+{%- endmacro %}
+
 
 {% macro ahvDisk() -%}
 
@@ -447,6 +460,9 @@ properties:
     type: array
     items:
       {{ ahvSerialPort() | indent(6) }}
+  vtpm_config:
+    x-calm-dsl-min-version: 4.1.0
+    {{ ahvVtpmConfig() | indent(4) }}
 
 {%- endmacro %}
 


### PR DESCRIPTION
Allowing vtpm_config attribute to be in ahv_vm provider spec.